### PR TITLE
[NLP-1852] Hammurabi v1.1.0 release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 - NLP-895: Improved logging
 - NLP-1596: Implement subprocess tests for examples
 - NLP-1642: Support leading whitespace in grammar
-- HCD-632: Loosen dependencies on librarires
+- HCD-632: Loosen dependencies on libraries
 
 1.0.0 (29.04.2020)
 ++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,10 @@
+1.1.0 (02.02.2021)
+++++++++++++++++++
+- NLP-895: Improved logging
+- NLP-1596: Implement subprocess tests for examples
+- NLP-1642: Support leading whitespace in grammar
+- HCD-632: Loosen dependencies on librarires
+
 1.0.0 (29.04.2020)
 ++++++++++++++++++
 - Initial open-source release

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ERROR_PYTHON_VERSION = 10
 ### Main defs
 
 PACKAGE_NAME = hmrb
-PACKAGE_VERSION = 1.0.1
+PACKAGE_VERSION = 1.1.0
 
 srcdir = $(CURDIR)/$(PACKAGE_NAME)
 builddir = $(CURDIR)/build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ import hmrb
 # -- Project information -----------------------------------------------------
 
 project = "hmrb"
-copyright = "2019, Babylon Health"
+copyright = "2021, Babylon Health"
 author = "Kristian Boda, Sasho Savkov"
 
 # The short X.Y version

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -21,4 +21,6 @@ Rules and heuristics are often used to kick start a project which has insufficie
 
 Release History
 ---------------
-:Version: ``v1.0 (31.12.2019)``
+:Version: ``v1.1.0 (02.02.2021)``
+
+          ``v1.0.0 (29.04.2020)``

--- a/hmrb/__init__.py
+++ b/hmrb/__init__.py
@@ -1,3 +1,3 @@
 name = "hmrb"
-__version__ = "1.1.0rc1"
+__version__ = "1.1.0"
 __release__ = __version__


### PR DESCRIPTION
```
1.1.0 (02.02.2021)
++++++++++++++++++
- NLP-895: Improved logging
- NLP-1596: Implement subprocess tests for examples
- NLP-1642: Support leading whitespace in grammar
- HCD-632: Loosen dependencies on libraries
```

Thanks @jack-babylon @savkov @alexmorley for your contributions!