### PR TITLE
[NLP-1954] Add example and tests for spaCy 2.2+

### DIFF
--- a/examples/spacy2.py
+++ b/examples/spacy2.py
@@ -1,0 +1,65 @@
+import spacy
+
+nlp = spacy.load("en_core_web_sm")
+sentences = 'I love gorillas. Peter loves gorillas. Jane loves Tarzan.'
+
+
+def conj_be(subj: str) -> str:
+    if subj == "I":
+        return "am"
+    elif subj == "you":
+        return "are"
+    else:
+        return "is"
+
+
+def gorilla_clb(seq: list, span: slice, data: dict) -> None:
+    subj = seq[span.start].text
+    be = conj_be(subj)
+    print(f"{subj} {be} a gorilla person.")
+
+
+def lover_clb(seq: list, span: slice, data: dict) -> None:
+    print(
+        f'{seq[span][-1]["text"]} is a love interest of'
+        f'{seq[span.start]["text"]}.'
+    )
+
+
+clbs = {"gorilla people": gorilla_clb, "lover": lover_clb}
+
+grammar = """
+Law:
+- callback: "gorilla people"
+(
+((pos: "PROPN") or (pos: "PRON"))
+(lemma: "love")
+(lemma: "gorilla")
+)
+Law:
+- callback: "lover"
+(
+(pos: "PROPN")
+(text: "loves")
+(pos: "PROPN")
+)
+"""
+
+def jsonify_span(span):
+    jsn = []
+    for token in span:
+        jsn.append({
+            'lemma': token.lemma_,
+            'pos': token.pos_,
+            'lower': token.lower_,
+        })
+    return jsn
+
+from hmrb.core import SpacyCore
+core = SpacyCore(callbacks=clbs,
+                 map_doc=jsonify_span,
+                 sort_length=True)
+
+core.load(grammar)
+nlp.add_pipe(core)
+nlp(sentences)

--- a/tests/test_spacy.py
+++ b/tests/test_spacy.py
@@ -1,0 +1,45 @@
+import pytest
+
+def jsonify_span(span):
+    jsn = []
+    for token in span:
+        jsn.append({
+            'lemma': token.lemma_,
+            'pos': token.pos_,
+            'lower': token.lower_,
+        })
+    return jsn
+
+def dummy_callback(seq: list, span: slice, data: dict) -> None:
+    print("OK")
+
+TEXT = "I feel great today."
+TEXT2 = "I love icecream."
+GRAMMAR = """
+Law:
+- callback: "pytest"
+(
+    ((pos: "PROPN") or (pos: "PRON"))
+    (lemma: "feel")
+    (lemma: "great")
+)
+"""
+CLBS = {"pytest": dummy_callback}
+
+def test_spacyV2(capsys):
+    spacy = pytest.importorskip("spacy")
+    assert spacy.__version__ == "2.3.5"
+    nlp = spacy.load("en_core_web_sm")
+
+    from hmrb.core import SpacyCore
+    core = SpacyCore(callbacks=CLBS,
+                 map_doc=jsonify_span,
+                 sort_length=True)
+    core.load(GRAMMAR)
+    nlp.add_pipe(core)
+    nlp(TEXT)
+    captured = capsys.readouterr()
+    assert captured[0] == 'OK\n'
+    nlp(TEXT2)
+    captured = capsys.readouterr()
+    assert captured[0] == ''


### PR DESCRIPTION
I've added a new example on how to use `hmrb` within spaCy 2.3.5.
I've also added a test checking spacy compatibility. This helps future development with spacy.

I've opted to not include these tests in CI (since they need the model + spacy installation) and should be run by the developer as a one off.
