### PR TITLE
[NLP-1955] Implement SpacyCore for spaCy 3.0+

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -33,7 +33,7 @@ First, we have to register both our augmenter functions `map_doc` and any callba
 
 Second, we have to create a configuration dictionary that contains the rules and references the callbacks and mapping functions as shown in the example below.
 
-Finally, we can add the ``"hammurabi"`` pipeline component using our configuration to the spaCy pipeline.
+Finally, we can add the ``"hmrb"`` pipeline component using our configuration to the spaCy pipeline.
 
 .. code-block:: python
 
@@ -51,11 +51,11 @@ Finally, we can add the ``"hammurabi"`` pipeline component using our configurati
     print("OK")
 
    conf = {
-       "rules" = GRAMMAR
-       "callbacks" = {"my_callback": "callbacks.dummy_callback"}
-       "map_doc" = "augmenters.jsonify_span"
+       "rules": GRAMMAR
+       "callbacks": {"my_callback": "callbacks.dummy_callback"}
+       "map_doc": "augmenters.jsonify_span"
    }
-   nlp.add_pipe("hammurabi", config=conf)
+   nlp.add_pipe("hmrb", config=conf)
 
 
 Handling Callbacks

--- a/examples/spacy2.py
+++ b/examples/spacy2.py
@@ -1,7 +1,7 @@
 import spacy
 
 nlp = spacy.load("en_core_web_sm")
-sentences = 'I love gorillas. Peter loves gorillas. Jane loves Tarzan.'
+sentences = "I love gorillas. Peter loves gorillas. Jane loves Tarzan."
 
 
 def conj_be(subj: str) -> str:
@@ -21,44 +21,41 @@ def gorilla_clb(seq: list, span: slice, data: dict) -> None:
 
 def lover_clb(seq: list, span: slice, data: dict) -> None:
     print(
-        f'{seq[span][-1]["text"]} is a love interest of'
-        f'{seq[span.start]["text"]}.'
+        f"{seq[span][-1].text} is a love interest of "
+        f"{seq[span.start].text}."
     )
 
 
-clbs = {"gorilla people": gorilla_clb, "lover": lover_clb}
+clbs = {"loves_gorilla": gorilla_clb, "loves_someone": lover_clb}
 
 grammar = """
 Law:
-- callback: "gorilla people"
+- callback: "loves_gorilla"
 (
 ((pos: "PROPN") or (pos: "PRON"))
 (lemma: "love")
 (lemma: "gorilla")
 )
 Law:
-- callback: "lover"
+- callback: "loves_someone"
 (
 (pos: "PROPN")
-(text: "loves")
+(lower: "loves")
 (pos: "PROPN")
 )
 """
 
+
 def jsonify_span(span):
-    jsn = []
-    for token in span:
-        jsn.append({
-            'lemma': token.lemma_,
-            'pos': token.pos_,
-            'lower': token.lower_,
-        })
-    return jsn
+    return [
+        {"lemma": token.lemma_, "pos": token.pos_, "lower": token.lower_}
+        for token in span
+    ]
+
 
 from hmrb.core import SpacyCore
-core = SpacyCore(callbacks=clbs,
-                 map_doc=jsonify_span,
-                 sort_length=True)
+
+core = SpacyCore(callbacks=clbs, map_doc=jsonify_span, sort_length=True)
 
 core.load(grammar)
 nlp.add_pipe(core)

--- a/examples/spacy3.py
+++ b/examples/spacy3.py
@@ -66,5 +66,5 @@ conf = {
     "sort_length": True,
 }
 
-nlp.add_pipe("hammurabi", config=conf)
+nlp.add_pipe("hmrb", config=conf)
 nlp(sentences)

--- a/examples/spacy3.py
+++ b/examples/spacy3.py
@@ -1,0 +1,70 @@
+import spacy
+
+nlp = spacy.load("en_core_web_sm")
+sentences = "I love gorillas. Peter loves gorillas. Jane loves Tarzan."
+
+
+def conj_be(subj: str) -> str:
+    if subj == "I":
+        return "am"
+    elif subj == "you":
+        return "are"
+    else:
+        return "is"
+
+
+@spacy.registry.callbacks("gorilla_callback")
+def gorilla_clb(seq: list, span: slice, data: dict) -> None:
+    subj = seq[span.start].text
+    be = conj_be(subj)
+    print(f"{subj} {be} a gorilla person.")
+
+
+@spacy.registry.callbacks("lover_callback")
+def lover_clb(seq: list, span: slice, data: dict) -> None:
+    print(
+        f"{seq[span][-1].text} is a love interest of "
+        f"{seq[span.start].text}."
+    )
+
+
+grammar = """
+Law:
+- callback: "loves_gorilla"
+(
+((pos: "PROPN") or (pos: "PRON"))
+(lemma: "love")
+(lemma: "gorilla")
+)
+Law:
+- callback: "loves_someone"
+(
+(pos: "PROPN")
+(lower: "loves")
+(pos: "PROPN")
+)
+"""
+
+
+@spacy.registry.augmenters("jsonify_span")
+def jsonify_span(span):
+    return [
+        {"lemma": token.lemma_, "pos": token.pos_, "lower": token.lower_}
+        for token in span
+    ]
+
+
+from hmrb.core import SpacyCore
+
+conf = {
+    "rules": grammar,
+    "callbacks": {
+        "loves_gorilla": "callbacks.gorilla_callback",
+        "loves_someone": "callbacks.lover_callback",
+    },
+    "map_doc": "augmenters.jsonify_span",
+    "sort_length": True,
+}
+
+nlp.add_pipe("hammurabi", config=conf)
+nlp(sentences)

--- a/hmrb/core.py
+++ b/hmrb/core.py
@@ -244,7 +244,7 @@ try:
         return core
 
     Language.factory(
-        "hammurabi",
+        "hmrb",
         default_config={
             "callbacks": {},
             "sets": {},

--- a/hmrb/core.py
+++ b/hmrb/core.py
@@ -117,9 +117,7 @@ class Core:
             for data in matches:
                 callback_name = data.get("callback")
                 logging.info(f"_execute: callback <{callback_name}>")
-                callback = self.callbacks.get(
-                    callback_name, Core.default_callback
-                )
+                callback = self.callbacks.get(callback_name, Core.default_callback)
                 try:
                     callback(input_, slice(*span), data)
                 except Exception as ex:
@@ -190,9 +188,7 @@ class SpacyCore(Core):
         map_doc: Callable = _default_map,
         sort_length: bool = False,
     ):
-        super().__init__(
-            callbacks=callbacks, sets=sets, sort_length=sort_length
-        )
+        super().__init__(callbacks=callbacks, sets=sets, sort_length=sort_length)
         self.map_doc = map_doc
 
     def __call__(self, doc: Any) -> Any:
@@ -230,13 +226,20 @@ try:
     from spacy.language import Language
     from spacy import registry
 
-    def spacy_factory(nlp, name, callbacks, sets, map_doc, sort_length, rules):
-        map_doc = registry.get(*map_doc.split("."))
+    def spacy_factory(
+        nlp: object,
+        name: str,
+        callbacks: dict,
+        sets: dict,
+        map_doc: str,
+        sort_length: bool,
+        rules: str,
+    ) -> SpacyCore:
+        map_fn = registry.get(*map_doc.split("."))
         callbacks = {
-            key: registry.get(*value.split("."))
-            for key, value in callbacks.items()
+            key: registry.get(*value.split(".")) for key, value in callbacks.items()
         }
-        core = SpacyCore(callbacks, sets, map_doc, sort_length)
+        core = SpacyCore(callbacks, sets, map_fn, sort_length)
         core.load(rules)
         return core
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -62,6 +62,32 @@ def tests(session: Session) -> None:
     session.run("coverage", "xml")
 
 
+@nox.session(python=["3.9"])
+def test_spacy2(session: Session) -> None:
+    session.install("pytest")
+    session.install("spacy<3.0.0")
+    session.run("spacy", "download", "en_core_web_sm")
+    session.install("-r", "requirements.txt")
+    session.install("-e", ".")
+    session.run(
+        "pytest",
+        "tests/test_spacy.py",
+        )
+
+
+@nox.session(python=["3.9"])
+def test_spacy3(session: Session) -> None:
+    session.install("pytest")
+    session.install("spacy>=3.0.0")
+    session.run("spacy", "download", "en_core_web_sm")
+    session.install("-r", "requirements.txt")
+    session.install("-e", ".")
+    session.run(
+        "pytest",
+        "tests/test_spacy.py",
+        )
+
+
 @nox.session(python=["3.7"])
 def changelog(session: Session) -> None:
     args = session.posargs or ["--unreleased"]

--- a/tests/test_spacy.py
+++ b/tests/test_spacy.py
@@ -1,18 +1,18 @@
 import pytest
+
 spacy = pytest.importorskip("spacy")
 
+
 def jsonify_span(span):
-    jsn = []
-    for token in span:
-        jsn.append({
-            'lemma': token.lemma_,
-            'pos': token.pos_,
-            'lower': token.lower_,
-        })
-    return jsn
+    return [
+        {"lemma": token.lemma_, "pos": token.pos_, "lower": token.lower_}
+        for token in span
+    ]
+
 
 def dummy_callback(seq: list, span: slice, data: dict) -> None:
     print("OK")
+
 
 TEXT = "I feel great today."
 TEXT2 = "I love icecream."
@@ -26,22 +26,26 @@ Law:
 )
 """
 
+
 def test_spacyV2(capsys):
     if spacy.__version__ >= "3.0.0":
         pytest.skip(f"Invalid spacy version {spacy.__version__}")
     nlp = spacy.load("en_core_web_sm")
     from hmrb.core import SpacyCore
-    core = SpacyCore(callbacks={"pytest": dummy_callback},
-                 map_doc=jsonify_span,
-                 sort_length=True)
+
+    core = SpacyCore(
+        callbacks={"pytest": dummy_callback},
+        map_doc=jsonify_span,
+        sort_length=True,
+    )
     core.load(GRAMMAR)
     nlp.add_pipe(core)
     nlp(TEXT)
     captured = capsys.readouterr()
-    assert captured[0] == 'OK\n'
+    assert captured[0] == "OK\n"
     nlp(TEXT2)
     captured = capsys.readouterr()
-    assert captured[0] == ''
+    assert captured[0] == ""
 
 
 def test_spacyV3(capsys):
@@ -59,15 +63,15 @@ def test_spacyV3(capsys):
         return dummy_callback(*args, **kwargs)
 
     conf = {}
-    conf['rules']=GRAMMAR
-    conf['callbacks'] = {"pytest": "callbacks.dummy_callback"}
-    conf['map_doc']="augmenters.jsonify_span"
-    conf['sort_length']=True
+    conf["rules"] = GRAMMAR
+    conf["callbacks"] = {"pytest": "callbacks.dummy_callback"}
+    conf["map_doc"] = "augmenters.jsonify_span"
+    conf["sort_length"] = True
 
     nlp.add_pipe("hammurabi", config=conf)
     nlp(TEXT)
     captured = capsys.readouterr()
-    assert captured[0] == 'OK\n'
+    assert captured[0] == "OK\n"
     nlp(TEXT2)
     captured = capsys.readouterr()
-    assert captured[0] == ''
+    assert captured[0] == ""

--- a/tests/test_spacy.py
+++ b/tests/test_spacy.py
@@ -68,7 +68,7 @@ def test_spacyV3(capsys):
     conf["map_doc"] = "augmenters.jsonify_span"
     conf["sort_length"] = True
 
-    nlp.add_pipe("hammurabi", config=conf)
+    nlp.add_pipe("hmrb", config=conf)
     nlp(TEXT)
     captured = capsys.readouterr()
     assert captured[0] == "OK\n"


### PR DESCRIPTION
Context: 
this PR enables the new Language.component API for spaCy 3.0 while continuing to support spaCy 2.0.

Factory API: https://spacy.io/api/language#factory
Registry API: https://spacy.io/usage/training#data-augmentation-custom the `get` method comes from Thinc.

- [x] Implement tests for both spaCy versions `2.3` and `3.0+`
- [x] Refactor SpacyCore to support both spaCy versions `2.3` and `3.0+`
- [x] Add spaCy `3.0` example
- [x] Update documentation to include spaCy `3.0` section