### PR TITLE
Suggestion to include the imported Class

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -55,7 +55,7 @@ Finally, we can add the ``"hmrb"`` pipeline component using our configuration to
        "callbacks": {"my_callback": "callbacks.dummy_callback"}
        "map_doc": "augmenters.jsonify_span"
    }
-   nlp.add_pipe("hmrb", config=conf)
+   nlp.add_pipe(SpacyCore.name, config=conf)
 
 
 Handling Callbacks


### PR DESCRIPTION
Pycharm has consistently removed the import of SpacyCore when optimising imports because it is not used explicitly in the code. This little change fixes that and clarifies where the nlp pipe name comes from. Gentle suggestion. 

(Aside, I've started exploring `hmrb` and really like the ease of constructing the grammar objects so far -- thanks for the package!)